### PR TITLE
sprint10-AQD611-NitrogenDioxideHourlyDataDownload

### DIFF
--- a/test/page-objects/common.js
+++ b/test/page-objects/common.js
@@ -25,6 +25,16 @@ class Common {
   get continueButton() {
     return $("button[type='submit']")
   }
+
+  async getList(pageElement) {
+    const elements = await $$(pageElement)
+    const headingsText = []
+    for (const el of elements) {
+      const text = await el.getText()
+      headingsText.push(text)
+    }
+    return headingsText
+  }
 }
 
 export default new Common()

--- a/test/page-objects/locationMonitoringStationListPage.js
+++ b/test/page-objects/locationMonitoringStationListPage.js
@@ -51,10 +51,6 @@ class LocationMonitoringStationListPage {
     return $("th[class='govuk-table__cell']")
   }
 
-  get getPollutantList1() {
-    return $$("td[class='govuk-table__cell govuk-table__cell--numeric']")[1]
-  }
-
   async getPollutionListFromListPage(pollutantList) {
     const table = await $(pollutantList) // "td[class='govuk-table__cell govuk-table__cell--numeric']"[1]
     const Elements = await table.$$('li')

--- a/test/page-objects/monitoringStationPage.js
+++ b/test/page-objects/monitoringStationPage.js
@@ -189,6 +189,14 @@ class MonitoringStationPage {
   get getDownloadOzoneHourlyDataLink() {
     return $$("a[id*='download-link']")[9]
   }
+
+  get getNitrogenDioxideSubHeading() {
+    return $$("h2[id*='all-p']")[2]
+  }
+
+  get getDownloadNitrogenDioxideHourlyDataLink() {
+    return $$("a[id*='download-link']")[6]
+  }
 }
 
 // module.exports=new StartNowPage()

--- a/test/specs/monitoringStationPageValidation.js
+++ b/test/specs/monitoringStationPageValidation.js
@@ -1191,6 +1191,100 @@ View on Google Maps (opens in new tab)`
     }
   })
 
+  it('Download Hourly Data for Nitrogen Dioxide, AQD-611', async () => {
+    const getNitrogenDioxideSubHeading =
+      await monitoringStationPage.getNitrogenDioxideSubHeading.getText()
+    const expectedgetNitrogenDioxideSubHeading = 'Nitrogen dioxide'
+    await expect(getNitrogenDioxideSubHeading).toMatch(
+      expectedgetNitrogenDioxideSubHeading
+    )
+
+    const getDownloadNitrogenDioxideHourlyDataLink =
+      await monitoringStationPage.getDownloadNitrogenDioxideHourlyDataLink.getText()
+    await monitoringStationPage.getDownloadNitrogenDioxideHourlyDataLink.isDisplayed()
+    await monitoringStationPage.getDownloadNitrogenDioxideHourlyDataLink.isClickable()
+    const expectedDownloadNitrogenDioxideHourlyDataLink = 'Download hourly data'
+    await expect(getDownloadNitrogenDioxideHourlyDataLink).toMatch(
+      expectedDownloadNitrogenDioxideHourlyDataLink
+    )
+
+    const NitrogenDioxideSubHeading = [
+      await monitoringStationPage.getNitrogenDioxideSubHeading
+    ]
+
+    const getNitrogenDioxideSubHeadingProperties = [
+      'margin-bottom',
+      'font-size',
+      'line-height',
+      'color',
+      'font-family',
+      'font-weight'
+    ]
+
+    for (const element of NitrogenDioxideSubHeading) {
+      const styles = await common.getStyles(
+        element,
+        getNitrogenDioxideSubHeadingProperties
+      )
+      expect(styles['margin-bottom']).toBe('20px')
+      expect(styles['font-size']).toBe('24px')
+      expect(styles['line-height']).toBe('30px')
+      expect(styles.color).toBe('rgb(11, 12, 12)')
+      expect(styles['font-family']).toBe('"GDS Transport", arial, sans-serif')
+      expect(styles['font-weight']).toBe('700')
+    }
+
+    const DownloadNitrogenDioxideHourlyDataLink = [
+      await monitoringStationPage.getDownloadNitrogenDioxideHourlyDataLink
+    ]
+
+    const DownloadNitrogenDioxideHourlyDataLinkProperties = [
+      'font-size',
+      'line-height',
+      'display',
+      'font-family',
+      'background-color',
+      'border',
+      'color',
+      'font-weight',
+      'margin',
+      'outline',
+      'padding',
+      'margin-bottom'
+    ]
+
+    for (const element of DownloadNitrogenDioxideHourlyDataLink) {
+      const styles = await common.getStyles(
+        element,
+        DownloadNitrogenDioxideHourlyDataLinkProperties
+      )
+      expect(styles['font-size']).toBe('16px')
+      expect(styles['line-height']).toBe('20px')
+      expect(styles.display).toBe('inline-block')
+      expect(styles['font-family']).toBe('"GDS Transport", arial, sans-serif')
+      expect(styles['background-color']).toBe('rgb(255, 255, 255)')
+      expect(styles.border).toBe('0.666667px solid rgb(177, 180, 182)')
+      expect(styles.color).toBe('rgb(11, 12, 12)')
+      expect(styles['font-weight']).toBe('400')
+      expect(styles.margin).toBe('0px 0px 15px')
+      expect(styles.outline).toBe('rgba(0, 0, 0, 0) solid 2.66667px')
+      expect(styles.padding).toBe('9px 10px 10px')
+      expect(styles['margin-bottom']).toBe('15px')
+    }
+
+    const pollutantDownloadListOrder = await common.getList('h2[id=all-p]')
+    const expectedpollutantDownloadListOrder = [
+      'PM2.5',
+      'PM10',
+      'Nitrogen dioxide',
+      'Ozone',
+      'Sulphur dioxide'
+    ]
+    await expect(pollutantDownloadListOrder).toEqual(
+      expectedpollutantDownloadListOrder
+    )
+  })
+
   it('checkng google link', async () => {
     await monitoringStationPage.getGoogleMapLink.click()
     // await monitoringStationPage.getGoogleCookieAccept.click()


### PR DESCRIPTION
forgot to create a new branch apologies 
>A ‘Nitrogen dioxide’ sub-section is made available 

>The Download hourly data button is made available and clickable 

>The design aligns to the prototype

Ordering of this section follows:
PM2.5
PM10
Nitrogen dioxide
Ozone
Sulphur dioxide