### PR TITLE
cookies banner tests

### DIFF
--- a/test/page-objects/cookiesBanner.js
+++ b/test/page-objects/cookiesBanner.js
@@ -1,0 +1,60 @@
+/* eslint-disable prettier/prettier */
+class CookiesBanner {
+  get getCookieBanner() {
+    return $("div[class*='govuk-cookie-banner']")
+  }
+
+  get getCookieBannerHeading() {
+    return $("h2[class*='govuk-cookie-banner__heading govuk-heading-m']")
+  }
+
+  get getCookieBannerContent() {
+    return $("div[class*='govuk-cookie-banner__content']")
+  }
+
+  get getCookieBannerContentStyling() {
+    return $("p[class*='govuk-body']")
+  }
+
+  get getViewCookiesLink() {
+    return $$("a[href*='/cookies/']")[0]
+  }
+
+  get getAcceptCookiesButton() {
+    return $("button[class*='govuk-button js-cookie-banner-accept']")
+  }
+
+  get getCookieAcceptedContent() {
+    return $$("div[class*='govuk-cookie-banner__content']")[1]
+  }
+
+  get getChangeCookieSettings() {
+    return $$("a[href*='/cookies']")[1]
+  }
+
+  get getRejectCookiesButton() {
+    return $("button[class*='govuk-button js-cookie-banner-reject']")
+  }
+
+  get getCookieRejectedContent() {
+    return $$("div[class*='govuk-cookie-banner__content']")[2]
+  }
+
+  get getChangeCookieSettingsAfterReject() {
+    return $$("a[class*='govuk-link']")[2]
+  }
+
+  get getHideCookiesButton() {
+    return $(
+      "button[class*='govuk-button js-cookie-banner-hide js-cookie-banner-hide--accept']"
+    )
+  }
+
+  get getHideCookiesButtonAfterReject() {
+    return $(
+      "button[class*='govuk-button js-cookie-banner-hide js-cookie-banner-hide--reject']"
+    )
+  }
+}
+
+export default new CookiesBanner()

--- a/test/specs/cookiesValidation.js
+++ b/test/specs/cookiesValidation.js
@@ -1,0 +1,291 @@
+import { browser, expect } from '@wdio/globals'
+// import fs from 'node:fs'
+// import createLogger from 'helpers/logger'
+import common from '../page-objects/common.js'
+import passwordPage from '../page-objects/passwordPage.js'
+import cookiesBanner from '../page-objects/cookiesBanner.js'
+describe('Cookies Tests', () => {
+  it('cookiebanner, AQD-651, displayed and styling', async () => {
+    await browser.deleteCookies(['airaqie_cookies_analytics'])
+    await browser.url('')
+    await browser.maximizeWindow()
+    await passwordPage.inputPassword('airqualitydataset')
+    await common.continueButton.click()
+    await cookiesBanner.getCookieBanner.isDisplayed()
+
+    const getCookieBanner = [await cookiesBanner.getCookieBanner]
+
+    const getCookieBannerProperties = [
+      'background-color',
+      'border-bottom',
+      'padding-top'
+    ]
+
+    for (const element of getCookieBanner) {
+      const styles = await common.getStyles(element, getCookieBannerProperties)
+      expect(styles['background-color']).toBe('rgb(243, 242, 241)')
+      expect(styles['border-bottom']).toBe('10px solid rgba(0, 0, 0, 0)')
+      expect(styles['padding-top']).toBe('20px')
+    }
+
+    const getCookieBannerHeading = [await cookiesBanner.getCookieBannerHeading]
+
+    const getCookieBannerHeadingProperties = [
+      'margin-bottom',
+      'font-size',
+      'line-height',
+      'color',
+      'font-family',
+      'font-weight'
+    ]
+
+    for (const element of getCookieBannerHeading) {
+      const styles = await common.getStyles(
+        element,
+        getCookieBannerHeadingProperties
+      )
+      expect(styles['margin-bottom']).toBe('20px')
+      expect(styles['font-size']).toBe('24px')
+      expect(styles['line-height']).toBe('30px')
+      expect(styles.color).toBe('rgb(11, 12, 12)')
+      expect(styles['font-family']).toBe('"GDS Transport", arial, sans-serif')
+      expect(styles['font-weight']).toBe('700')
+    }
+
+    const getCookieBannerContentStyling = [
+      await cookiesBanner.getCookieBannerContentStyling
+    ]
+
+    const getCookieBannerContentStylingProperties = [
+      'margin-bottom',
+      'font-size',
+      'line-height',
+      'color',
+      'font-family',
+      'font-weight'
+    ]
+
+    for (const element of getCookieBannerContentStyling) {
+      const styles = await common.getStyles(
+        element,
+        getCookieBannerContentStylingProperties
+      )
+      expect(styles['margin-bottom']).toBe('20px')
+      expect(styles['font-size']).toBe('19px')
+      expect(styles['line-height']).toBe('25px')
+      expect(styles.color).toBe('rgb(11, 12, 12)')
+      expect(styles['font-family']).toBe('"GDS Transport", arial, sans-serif')
+      expect(styles['font-weight']).toBe('400')
+    }
+
+    const getViewCookiesLink = [await cookiesBanner.getViewCookiesLink]
+
+    const getViewCookiesLinkProperties = [
+      'text-align',
+      'margin-right',
+      'font-size',
+      'line-height',
+      'font-family',
+      'font-weight',
+      'margin-bottom',
+      'margin-top',
+      'color',
+      'text-decoration'
+    ]
+
+    for (const element of getViewCookiesLink) {
+      const styles = await common.getStyles(
+        element,
+        getViewCookiesLinkProperties
+      )
+      expect(styles['text-align']).toBe('left')
+      expect(styles['margin-right']).toBe('15px')
+      expect(styles['font-size']).toBe('19px')
+      expect(styles['line-height']).toBe('19px')
+      expect(styles['font-family']).toBe('"GDS Transport", arial, sans-serif')
+      expect(styles['font-weight']).toBe('400')
+      expect(styles['margin-bottom']).toBe('20px')
+      expect(styles['margin-top']).toBe('5px')
+      expect(styles.color).toBe('rgb(29, 112, 184)')
+      expect(styles['text-decoration']).toBe(
+        'underline 1px solid rgb(29, 112, 184)'
+      )
+    }
+
+    const getAcceptCookiesButton = [await cookiesBanner.getAcceptCookiesButton]
+
+    const getAcceptCookiesButtonProperties = [
+      'background',
+      'display',
+      'font-size',
+      'line-height',
+      'font-family',
+      'background-color',
+      'border',
+      'box-shadow',
+      'box-sizing',
+      'color',
+      'font-weight',
+      'margin',
+      'padding',
+      'text-align'
+    ]
+
+    for (const element of getAcceptCookiesButton) {
+      const styles = await common.getStyles(
+        element,
+        getAcceptCookiesButtonProperties
+      )
+      expect(styles.background).toBe(
+        'rgb(0, 112, 60) none repeat scroll 0% 0% / auto padding-box border-box'
+      )
+      expect(styles.display).toBe('block')
+      expect(styles['font-size']).toBe('19px')
+      expect(styles['line-height']).toBe('19px')
+      expect(styles['font-family']).toBe('"GDS Transport", arial, sans-serif')
+      expect(styles['background-color']).toBe('rgb(0, 112, 60)')
+      expect(styles.border).toBe('2px solid rgba(0, 0, 0, 0)')
+      expect(styles['box-shadow']).toBe('rgb(0, 45, 24) 0px 2px 0px 0px')
+      expect(styles['box-sizing']).toBe('border-box')
+      expect(styles.color).toBe('rgb(255, 255, 255)')
+      expect(styles['font-weight']).toBe('400')
+      expect(styles.margin).toBe('0px 15px 17px 0px')
+      expect(styles.padding).toBe('8px 10px 7px')
+      expect(styles['text-align']).toBe('center')
+    }
+  })
+
+  // different tests with buttons and links
+  it('cookiebanner, AQD-651, view cookies link', async () => {
+    await cookiesBanner.getViewCookiesLink.click()
+    const getCookiesPageURL = await browser.getUrl()
+    const expectedCookiesPageURL =
+      'https://aqie-dataselector-frontend.test.cdp-int.defra.cloud/cookies/'
+    await expect(getCookiesPageURL).toMatch(expectedCookiesPageURL)
+    browser.back()
+    browser.refresh()
+  })
+
+  it('cookiebanner, AQD-651, accept cookies scenario', async () => {
+    await cookiesBanner.getAcceptCookiesButton.click()
+    const getAcceptText = await cookiesBanner.getCookieAcceptedContent.getText()
+    const expectedAcceptText = `You’ve accepted analytics cookies. You can change your cookie settings at any time.`
+    await expect(getAcceptText).toMatch(expectedAcceptText)
+    await cookiesBanner.getChangeCookieSettings.click()
+    const getCookiesPageURL = await browser.getUrl()
+    const expectedCookiesPageURL =
+      'https://aqie-dataselector-frontend.test.cdp-int.defra.cloud/cookies'
+    await expect(getCookiesPageURL).toMatch(expectedCookiesPageURL)
+    browser.back()
+    await cookiesBanner.getHideCookiesButton.isDisplayed()
+
+    const getHideCookiesButton = [await cookiesBanner.getHideCookiesButton]
+
+    const getHideCookiesButtonProperties = [
+      'background',
+      'display',
+      'font-size',
+      'line-height',
+      'font-family',
+      'background-color',
+      'border',
+      'box-shadow',
+      'box-sizing',
+      'color',
+      'font-weight',
+      'margin',
+      'padding',
+      'text-align'
+    ]
+
+    for (const element of getHideCookiesButton) {
+      const styles = await common.getStyles(
+        element,
+        getHideCookiesButtonProperties
+      )
+      expect(styles.background).toBe(
+        'rgb(0, 112, 60) none repeat scroll 0% 0% / auto padding-box border-box'
+      )
+      expect(styles.display).toBe('block')
+      expect(styles['font-size']).toBe('19px')
+      expect(styles['line-height']).toBe('19px')
+      expect(styles['font-family']).toBe('"GDS Transport", arial, sans-serif')
+      expect(styles['background-color']).toBe('rgb(0, 112, 60)')
+      expect(styles.border).toBe('2px solid rgba(0, 0, 0, 0)')
+      expect(styles['box-shadow']).toBe('rgb(0, 45, 24) 0px 2px 0px 0px')
+      expect(styles['box-sizing']).toBe('border-box')
+      expect(styles.color).toBe('rgb(255, 255, 255)')
+      expect(styles['font-weight']).toBe('400')
+      expect(styles.margin).toBe('0px 15px 17px 0px')
+      expect(styles.padding).toBe('8px 10px 7px')
+      expect(styles['text-align']).toBe('center')
+    }
+    await cookiesBanner.getHideCookiesButton.click()
+    await cookiesBanner.getHideCookiesButton.waitForDisplayed({ reverse: true })
+  })
+
+  it('cookiebanner, AQD-651, reject cookies scenario', async () => {
+    await browser.deleteCookies(['airaqie_cookies_analytics'])
+    await browser.refresh()
+    await cookiesBanner.getRejectCookiesButton.click()
+    const getRejectedText =
+      await cookiesBanner.getCookieRejectedContent.getText()
+    const expectedRejectedText = `You’ve rejected analytics cookies. You can change your cookie settings at any time.`
+    await expect(getRejectedText).toMatch(expectedRejectedText)
+    await cookiesBanner.getChangeCookieSettingsAfterReject.click()
+    const getCookiesPageURL = await browser.getUrl()
+    const expectedCookiesPageURL =
+      'https://aqie-dataselector-frontend.test.cdp-int.defra.cloud/cookies'
+    await expect(getCookiesPageURL).toMatch(expectedCookiesPageURL)
+    browser.back()
+    await cookiesBanner.getHideCookiesButtonAfterReject.isDisplayed()
+
+    const getHideCookiesButton = [
+      await cookiesBanner.getHideCookiesButtonAfterReject
+    ]
+
+    const getHideCookiesButtonProperties = [
+      'background',
+      'display',
+      'font-size',
+      'line-height',
+      'font-family',
+      'background-color',
+      'border',
+      'box-shadow',
+      'box-sizing',
+      'color',
+      'font-weight',
+      'margin',
+      'padding',
+      'text-align'
+    ]
+
+    for (const element of getHideCookiesButton) {
+      const styles = await common.getStyles(
+        element,
+        getHideCookiesButtonProperties
+      )
+      expect(styles.background).toBe(
+        'rgb(0, 112, 60) none repeat scroll 0% 0% / auto padding-box border-box'
+      )
+      expect(styles.display).toBe('block')
+      expect(styles['font-size']).toBe('19px')
+      expect(styles['line-height']).toBe('19px')
+      expect(styles['font-family']).toBe('"GDS Transport", arial, sans-serif')
+      expect(styles['background-color']).toBe('rgb(0, 112, 60)')
+      expect(styles.border).toBe('2px solid rgba(0, 0, 0, 0)')
+      expect(styles['box-shadow']).toBe('rgb(0, 45, 24) 0px 2px 0px 0px')
+      expect(styles['box-sizing']).toBe('border-box')
+      expect(styles.color).toBe('rgb(255, 255, 255)')
+      expect(styles['font-weight']).toBe('400')
+      expect(styles.margin).toBe('0px 15px 17px 0px')
+      expect(styles.padding).toBe('8px 10px 7px')
+      expect(styles['text-align']).toBe('center')
+    }
+    await cookiesBanner.getHideCookiesButtonAfterReject.click()
+    await cookiesBanner.getHideCookiesButtonAfterReject.waitForDisplayed({
+      reverse: true
+    })
+  })
+})

--- a/wdio.local.conf.js
+++ b/wdio.local.conf.js
@@ -28,7 +28,7 @@ export const config = {
   // then the current working directory is where your `package.json` resides, so `wdio`
   // will be called from there.
   //
-  specs: ['./test/specs/**/errorScenariosAndBugs.js'],
+  specs: ['./test/specs/**/cookiesValidation.js'],
   // Patterns to exclude.
   exclude: [],
   // injectGlobals: false,


### PR DESCRIPTION
Cookies banner is displayed on the top of the service when a user first navigates to the start page
-cookies banner matches the prototype
-If the user clicks ‘Accepts analytics cookies’ user is shown hide option, If the user clicks ‘Hide cookie message’, the cookie banner is then removed
-If the user clicks the hyperlink change your cookie settings, the user is navigated to the cookies page of the service
-If the user clicks on the hyperlink View cookies (on the initial cookie banner), then the user is navigated to the cookies page of the service