### PR TITLE
annual average toggle tips

### DIFF
--- a/test/page-objects/monitoringStationPage.js
+++ b/test/page-objects/monitoringStationPage.js
@@ -347,25 +347,55 @@ class MonitoringStationPage {
   get getNOHourlyExceedenceToggleTip() {
     return $$(
       "button[class*='tooltip defra-toggletip__button defra-toggletip-target']"
-    )[2]
+    )[5]
   }
 
   get getSDHourlyExceedenceToggleTip() {
     return $$(
       "button[class*='tooltip defra-toggletip__button defra-toggletip-target']"
-    )[4]
+    )[9]
   }
 
   get getPM10DailyExceedenceToggleTip() {
     return $$(
       "button[class*='tooltip defra-toggletip__button defra-toggletip-target']"
-    )[1]
+    )[3]
   }
 
   get getSDDailyExceedenceToggleTip() {
     return $$(
       "button[class*='tooltip defra-toggletip__button defra-toggletip-target']"
-    )[3]
+    )[8]
+  }
+
+  get getPM25AnnualAverageToggleTip() {
+    return $$(
+      "button[class*='tooltip defra-toggletip__button defra-toggletip-target']"
+    )[1]
+  }
+
+  get getPM10AnnualAverageToggleTip() {
+    return $$(
+      "button[class*='tooltip defra-toggletip__button defra-toggletip-target']"
+    )[2]
+  }
+
+  get getNitrogenDioxideAnnualAverageToggleTip() {
+    return $$(
+      "button[class*='tooltip defra-toggletip__button defra-toggletip-target']"
+    )[4]
+  }
+
+  get getOzoneAnnualAverageToggleTip() {
+    return $$(
+      "button[class*='tooltip defra-toggletip__button defra-toggletip-target']"
+    )[6]
+  }
+
+  get getSulphurDioxideAnnualAverageToggleTip() {
+    return $(
+      "button[aria-label*='More information about the UK annual average limit value for sulphur dioxide']"
+    )
   }
 
   get getPM25DataCapture() {

--- a/test/specs/exceedancesValidation.js
+++ b/test/specs/exceedancesValidation.js
@@ -622,4 +622,216 @@ describe('exceedences', () => {
       expect(styles.width).toBe('26px')
     }
   })
+
+  it('Toggle Tips for annaul average, AQD-686', async () => {
+    await monitoringStationPage.getPM25AnnualAverageToggleTip.isDisplayed()
+    await monitoringStationPage.getPM25AnnualAverageToggleTip.isClickable()
+
+    await monitoringStationPage.getPM10AnnualAverageToggleTip.isDisplayed()
+    await monitoringStationPage.getPM10AnnualAverageToggleTip.isClickable()
+
+    await monitoringStationPage.getNitrogenDioxideAnnualAverageToggleTip.isDisplayed()
+    await monitoringStationPage.getNitrogenDioxideAnnualAverageToggleTip.isClickable()
+
+    await monitoringStationPage.getOzoneAnnualAverageToggleTip.isDisplayed()
+    await monitoringStationPage.getOzoneAnnualAverageToggleTip.isClickable()
+
+    await monitoringStationPage.getSulphurDioxideAnnualAverageToggleTip.isDisplayed()
+    await monitoringStationPage.getSulphurDioxideAnnualAverageToggleTip.isClickable()
+
+    const getPM25AnnualAverageToggleTip = [
+      await monitoringStationPage.getPM25AnnualAverageToggleTip
+    ]
+
+    const getPM25AnnualAverageToggleTipProperties = [
+      'background-color',
+      'border',
+      'color',
+      'cursor',
+      'height',
+      'left',
+      'padding',
+      'position',
+      'text-align',
+      'top',
+      'width'
+    ]
+
+    for (const element of getPM25AnnualAverageToggleTip) {
+      const styles = await common.getStyles(
+        element,
+        getPM25AnnualAverageToggleTipProperties
+      )
+      expect(styles['background-color']).toBe('rgb(255, 255, 255)')
+      expect(styles.border).toBe('0px none rgb(11, 12, 12)')
+      expect(styles.color).toBe('rgb(11, 12, 12)')
+      expect(styles.cursor).toBe('help')
+      expect(styles.height).toBe('26px')
+      expect(styles.left).toBe('0px')
+      expect(styles.padding).toBe('0px')
+      expect(styles.position).toBe('absolute')
+      expect(styles['text-align']).toBe('center')
+      expect(styles.top).toBe('0px')
+      expect(styles.width).toBe('26px')
+    }
+
+    const getPM10AnnualAverageToggleTip = [
+      await monitoringStationPage.getPM10AnnualAverageToggleTip
+    ]
+
+    const getPM10AnnualAverageToggleTipProperties = [
+      'background-color',
+      'border',
+      'color',
+      'cursor',
+      'height',
+      'left',
+      'padding',
+      'position',
+      'text-align',
+      'top',
+      'width'
+    ]
+
+    for (const element of getPM10AnnualAverageToggleTip) {
+      const styles = await common.getStyles(
+        element,
+        getPM10AnnualAverageToggleTipProperties
+      )
+      expect(styles['background-color']).toBe('rgb(255, 255, 255)')
+      expect(styles.border).toBe('0px none rgb(11, 12, 12)')
+      expect(styles.color).toBe('rgb(11, 12, 12)')
+      expect(styles.cursor).toBe('help')
+      expect(styles.height).toBe('26px')
+      expect(styles.left).toBe('0px')
+      expect(styles.padding).toBe('0px')
+      expect(styles.position).toBe('absolute')
+      expect(styles['text-align']).toBe('center')
+      expect(styles.top).toBe('0px')
+      expect(styles.width).toBe('26px')
+    }
+
+    const getNitrogenDioxideAnnualAverageToggleTip = [
+      await monitoringStationPage.getNitrogenDioxideAnnualAverageToggleTip
+    ]
+
+    const getNitrogenDioxideAnnualAverageToggleTipProperties = [
+      'background-color',
+      'border',
+      'color',
+      'cursor',
+      'height',
+      'left',
+      'padding',
+      'position',
+      'text-align',
+      'top',
+      'width'
+    ]
+
+    for (const element of getNitrogenDioxideAnnualAverageToggleTip) {
+      const styles = await common.getStyles(
+        element,
+        getNitrogenDioxideAnnualAverageToggleTipProperties
+      )
+      expect(styles['background-color']).toBe('rgb(255, 255, 255)')
+      expect(styles.border).toBe('0px none rgb(11, 12, 12)')
+      expect(styles.color).toBe('rgb(11, 12, 12)')
+      expect(styles.cursor).toBe('help')
+      expect(styles.height).toBe('26px')
+      expect(styles.left).toBe('0px')
+      expect(styles.padding).toBe('0px')
+      expect(styles.position).toBe('absolute')
+      expect(styles['text-align']).toBe('center')
+      expect(styles.top).toBe('0px')
+      expect(styles.width).toBe('26px')
+    }
+
+    const getOzoneAnnualAverageToggleTip = [
+      await monitoringStationPage.getOzoneAnnualAverageToggleTip
+    ]
+
+    const getOzoneAnnualAverageToggleTipProperties = [
+      'background-color',
+      'border',
+      'color',
+      'cursor',
+      'height',
+      'left',
+      'padding',
+      'position',
+      'text-align',
+      'top',
+      'width'
+    ]
+
+    for (const element of getOzoneAnnualAverageToggleTip) {
+      const styles = await common.getStyles(
+        element,
+        getOzoneAnnualAverageToggleTipProperties
+      )
+      expect(styles['background-color']).toBe('rgb(255, 255, 255)')
+      expect(styles.border).toBe('0px none rgb(11, 12, 12)')
+      expect(styles.color).toBe('rgb(11, 12, 12)')
+      expect(styles.cursor).toBe('help')
+      expect(styles.height).toBe('26px')
+      expect(styles.left).toBe('0px')
+      expect(styles.padding).toBe('0px')
+      expect(styles.position).toBe('absolute')
+      expect(styles['text-align']).toBe('center')
+      expect(styles.top).toBe('0px')
+      expect(styles.width).toBe('26px')
+    }
+
+    const getSulphurDioxideAnnualAverageToggleTip = [
+      await monitoringStationPage.getSulphurDioxideAnnualAverageToggleTip
+    ]
+
+    const getSulphurDioxideAnnualAverageToggleTipProperties = [
+      'background-color',
+      'border',
+      'color',
+      'cursor',
+      'height',
+      'left',
+      'padding',
+      'position',
+      'text-align',
+      'top',
+      'width'
+    ]
+
+    for (const element of getSulphurDioxideAnnualAverageToggleTip) {
+      const styles = await common.getStyles(
+        element,
+        getSulphurDioxideAnnualAverageToggleTipProperties
+      )
+      expect(styles['background-color']).toBe('rgb(255, 255, 255)')
+      expect(styles.border).toBe('0px none rgb(11, 12, 12)')
+      expect(styles.color).toBe('rgb(11, 12, 12)')
+      expect(styles.cursor).toBe('help')
+      expect(styles.height).toBe('26px')
+      expect(styles.left).toBe('0px')
+      expect(styles.padding).toBe('0px')
+      expect(styles.position).toBe('absolute')
+      expect(styles['text-align']).toBe('center')
+      expect(styles.top).toBe('0px')
+      expect(styles.width).toBe('26px')
+    }
+
+    await monitoringStationPage.get2020Button.click()
+    await browser.waitUntil(
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 4000))
+        return true
+      },
+      { timeout: 4000 }
+    )
+
+    await monitoringStationPage.getSulphurDioxideAnnualAverageToggleTip.waitForDisplayed(
+      {
+        reverse: true
+      }
+    )
+  })
 })

--- a/wdio.local.conf.js
+++ b/wdio.local.conf.js
@@ -28,7 +28,7 @@ export const config = {
   // then the current working directory is where your `package.json` resides, so `wdio`
   // will be called from there.
   //
-  specs: ['./test/specs/**/errorScenariosAndBugs.js'],
+  specs: ['./test/specs/**/exceedancesValidation.js'],
   // Patterns to exclude.
   exclude: [],
   // injectGlobals: false,


### PR DESCRIPTION
-	Display a toggle tip for each pollutant in the station summary table
•	When a pollutant has less than 75% data capture for a selected year, no toggle tip is displayed in the Average column, e.g.:
•	Design and behaviour aligns to the prototype