### PR TITLE
tower hamlets bug

### DIFF
--- a/test/specs/errorScenariosAndBugs.js
+++ b/test/specs/errorScenariosAndBugs.js
@@ -656,4 +656,17 @@ Contact the air quality team if you continue to get this error message`
       expect(styles.visibility).toBe('visible')
     }
   })
+
+  it('PM10 Toggle Tip not behaving as expected for Wrexham Monitoring Station, AQD-712', async () => {
+    await browser.url('')
+    await startNowPage.startNowBtnClick()
+    await searchPage.setsearch('Tower Hamlets')
+    await searchPage.milesOptionClick('5 miles')
+    await searchPage.continueBtnClick()
+    const noTowerHamletStation =
+      await errorPage.getCouldNotFindHeading.getText()
+    const expectedPageHeading =
+      "There are no monitoring stations within 5 miles of 'Tower Hamlets'"
+    await expect(noTowerHamletStation).toMatch(expectedPageHeading)
+  })
 })


### PR DESCRIPTION
-go to https://aiqe-dataservice-frontend.dev.cdp-int.defra.cloud/
-select start now button 
-search for London 
-select first result 
-select London Bloomsbury 

>check that tower hamlets is not on the list 